### PR TITLE
Use STRIDE_jll and DSSP_jll instead of user-installed executables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,18 @@ version = "0.2.1-DEV"
 
 [deps]
 Chemfiles = "46823bd8-5fb3-5f92-9aa0-96921f3dd015"
+DSSP_jll = "74334e00-59ce-546d-b517-81f3b7e1d491"
 PDBTools = "e29189f1-7114-4dbd-93d0-c5673a921a58"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+STRIDE_jll = "850473c1-9ef0-5df9-a957-757f4cde8b8b"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
 [compat]
 Chemfiles = "0.10"
+DSSP_jll = "4"
 PDBTools = "0.13.14"
 ProgressMeter = "1.7"
+STRIDE_jll = "1"
 TestItems = "0.1"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -17,25 +17,6 @@ This package parses [STRIDE]( http://webclu.bio.wzw.tum.de/stride/) and [DSSP](h
 
 ## Installation
 
-Obtain `stride` and/or `dssp` programs from the corresponding repositories, compile it and add it to your path:
-
-For `stride`:
-
-```bash
-git clone https://github.com/m3g/stride
-cd stride/src
-make
-cp ./stride /usr/local/bin # or somewhere in the path
-```
-
-For `dssp`:
-
-```
-sudo apt install dssp # on Ubuntu-based linux distributions
-```
-
-or go to: https://github.com/PDB-REDO/dssp
-
 In Julia, install `ProteinSecondaryStructures` with:
 
 ```julia

--- a/src/dssp.jl
+++ b/src/dssp.jl
@@ -2,8 +2,8 @@
 # Interface for the DSSP secondary stucture determination program
 #
 
-# Assume "dssp" is in the path
-dssp_executable = "dssp"
+import DSSP_jll
+dssp_executable = `$(DSSP_jll.mkdssp()) --mmcif-dictionary $(joinpath(DSSP_jll.artifact_dir, "share", "dssp", "mmcif_pdbx.dic"))`
 
 """
     dssp_run(pdb_file::String; selection="protein")

--- a/src/stride.jl
+++ b/src/stride.jl
@@ -2,8 +2,8 @@
 # Interface for the STRIDE secondary structure prediction program
 #
 
-# Assume "stride" is in the path
-stride_executable = "stride"
+import STRIDE_jll
+stride_executable = STRIDE_jll.stride_exe()
 
 """
     stride_run(pdb_file::String; selection="protein")


### PR DESCRIPTION
Fixes #3 

There are some test failures, it seems as if the secondary structure assignment of `mkdssp` from `DSSP_jll` is slightly different to the results expected from the tests.

Maybe it should also be a version bump to 0.3 if the results are different.