### PR TITLE
Set tight compat bounds for DSSP_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 [compat]
 Aqua = "0.6"
 Chemfiles = "0.10"
-DSSP_jll = "4"
+DSSP_jll = "= 4.3.1"
 PDBTools = "0.13.14"
 ProgressMeter = "1.7"
 STRIDE_jll = "1"


### PR DESCRIPTION
This sets tight compat bounds for `DSSP_jll`, as this dependency doesn't follow semantic versioning, and therefore might produce different results for different versions of the software. In particular, the next version of dssp is said to change its output format https://github.com/PDB-REDO/dssp/releases/tag/v4.4.0. This should also ensure reproducibility of results generated with a particular version of ProteinSecondaryStructures.jl.

We might want to do this for `STRIDE_jll` as well, although there currently aren't any new versions being made of it.