### PR TITLE
Use DSSP_jll v4.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 [compat]
 Aqua = "0.6"
 Chemfiles = "0.10"
-DSSP_jll = "= 4.3.1"
+DSSP_jll = "= 4.4.0"
 PDBTools = "0.13.14"
 ProgressMeter = "1.7"
 STRIDE_jll = "1"

--- a/src/dssp.jl
+++ b/src/dssp.jl
@@ -3,7 +3,7 @@
 #
 
 import DSSP_jll
-dssp_executable = `$(DSSP_jll.mkdssp()) --mmcif-dictionary $(joinpath(DSSP_jll.artifact_dir, "share", "dssp", "mmcif_pdbx.dic"))`
+dssp_executable = `$(DSSP_jll.mkdssp()) --mmcif-dictionary $(joinpath(DSSP_jll.artifact_dir, "share", "libcifpp", "mmcif_pdbx.dic"))`
 
 """
     dssp_run(pdb_file::String; selection="protein")


### PR DESCRIPTION
This updates the DSSP_jll version to 4.4.0.

Should the version number of ProteinSecondaryStructures with this change be 0.3.2 or 0.4.0? Not quite sure what semantic versioning would suggest here.