### PR TITLE
Use shorter name for mmcif_pdbx.dic file from DSSP_jll

### DIFF
--- a/src/dssp.jl
+++ b/src/dssp.jl
@@ -3,7 +3,7 @@
 #
 
 import DSSP_jll
-dssp_executable = `$(DSSP_jll.mkdssp()) --mmcif-dictionary $(joinpath(DSSP_jll.artifact_dir, "share", "libcifpp", "mmcif_pdbx.dic"))`
+dssp_executable = `$(DSSP_jll.mkdssp()) --mmcif-dictionary $(DSSP_jll.mmcif_pdbx_dic)`
 
 """
     dssp_run(pdb_file::String; selection="protein")


### PR DESCRIPTION
This uses the new `FileProduct` name from DSSP_jll v4.4.0+1 for the mmcif_pdbx.dic file.